### PR TITLE
Fix Matplotlib get_cmap deprecation warning

### DIFF
--- a/analyse_noun_network.py
+++ b/analyse_noun_network.py
@@ -1293,7 +1293,7 @@ def visualize_network(full_graph, all_centrality_df, component_graphs, output_di
     plt.figure(figsize=(16, 16))
     
     # Color map for components (cycle through colors)
-    cmap = plt.cm.get_cmap('tab20', len(component_graphs))
+    cmap = plt.get_cmap('tab20', len(component_graphs))
     
     # Use spring layout for the full graph
     pos = nx.spring_layout(full_graph, seed=42, k=0.3, iterations=100)


### PR DESCRIPTION
## Summary
- update component colormap code to use `plt.get_cmap`

## Testing
- `python analyse_noun_network.py --help` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683a6f97fa548325ac5806fb214e1373