### PR TITLE
Export sentence-level translations

### DIFF
--- a/website/data.py
+++ b/website/data.py
@@ -79,6 +79,18 @@ def get_skepticism_predictors(conn):
     FROM skepticism_predictors
     ORDER BY coefficient DESC
     """
-    
+
+    df = pd.read_sql_query(query, conn)
+    return df
+
+
+def get_all_sentences(conn):
+    """Retrieve all Greek and English sentences."""
+    query = """
+    SELECT passage_id, sentence_number, sentence, english_sentence
+    FROM greek_sentences
+    ORDER BY passage_id, sentence_number
+    """
+
     df = pd.read_sql_query(query, conn)
     return df

--- a/website/generators.py
+++ b/website/generators.py
@@ -28,6 +28,7 @@ def generate_home_page(output_dir, title, timestamp):
             <a href="skepticism/index.html">Skepticism Analysis</a>
             <a href="mythic_words.html">Mythic Words</a>
             <a href="skeptic_words.html">Skeptic Words</a>
+            <a href="sentences.html">Sentences</a>
             <a href="network_viz/index.html">Network Analysis</a>
         </nav>
         
@@ -102,6 +103,7 @@ def generate_mythic_page(passages_df, mythic_color_map, mythic_class_map, proper
             <a href=\"../skepticism/index.html\">Skepticism Analysis</a>
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
+            <a href=\"../sentences.html\">Sentences</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -211,6 +213,7 @@ def generate_mythic_page(passages_df, mythic_color_map, mythic_class_map, proper
             <a href=\"../skepticism/index.html\">Skepticism Analysis</a>
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
+            <a href=\"../sentences.html\">Sentences</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -268,6 +271,7 @@ def generate_skepticism_page(passages_df, skeptic_color_map, skeptic_class_map, 
             <a href=\"index.html\" class=\"active\">Skepticism Analysis</a>
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
+            <a href=\"../sentences.html\">Sentences</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -377,6 +381,7 @@ def generate_skepticism_page(passages_df, skeptic_color_map, skeptic_class_map, 
             <a href=\"index.html\" class=\"active\">Skepticism Analysis</a>
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
+            <a href=\"../sentences.html\">Sentences</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -429,6 +434,7 @@ def generate_mythic_words_page(mythic_predictors, output_dir, title):
             <a href="skepticism/index.html">Skepticism Analysis</a>
             <a href="mythic_words.html" class="active">Mythic Words</a>
             <a href="skeptic_words.html">Skeptic Words</a>
+            <a href="sentences.html">Sentences</a>
             <a href="network_viz/index.html">Network Analysis</a>
         </nav>
         
@@ -524,6 +530,7 @@ def generate_skeptic_words_page(skeptic_predictors, output_dir, title):
             <a href="skepticism/index.html">Skepticism Analysis</a>
             <a href="mythic_words.html">Mythic Words</a>
             <a href="skeptic_words.html" class="active">Skeptic Words</a>
+            <a href="sentences.html">Sentences</a>
             <a href="network_viz/index.html">Network Analysis</a>
         </nav>
         
@@ -590,4 +597,71 @@ def generate_skeptic_words_page(skeptic_predictors, output_dir, title):
     
     # Write the file
     with open(os.path.join(output_dir, 'skeptic_words.html'), 'w', encoding='utf-8') as f:
+        f.write(html_content)
+
+
+def generate_sentences_page(sentences_df, output_dir, title):
+    """Generate a page listing Greek passages split into sentences."""
+
+    html_content = f"""<!DOCTYPE html>
+    <html lang=\"en\">
+    <head>
+        <meta charset=\"UTF-8\">
+        <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+        <title>{title} - Sentences</title>
+        <link rel=\"stylesheet\" href=\"css/style.css\">
+    </head>
+    <body>
+        <header>
+            <h1>{title}</h1>
+            <p>Greek passages split into sentences with English translation</p>
+        </header>
+
+        <nav>
+            <a href=\"index.html\">Home</a>
+            <a href=\"mythic/index.html\">Mythic Analysis</a>
+            <a href=\"skepticism/index.html\">Skepticism Analysis</a>
+            <a href=\"mythic_words.html\">Mythic Words</a>
+            <a href=\"skeptic_words.html\">Skeptic Words</a>
+            <a href=\"sentences.html\" class=\"active\">Sentences</a>
+            <a href=\"network_viz/index.html\">Network Analysis</a>
+        </nav>
+
+        <div class=\"container\">
+            <h2>Sentence-level Translations</h2>
+            <table class=\"sentences-table\">
+                <thead>
+                    <tr>
+                        <th>Passage</th>
+                        <th>Sentence</th>
+                        <th>Greek</th>
+                        <th>English</th>
+                    </tr>
+                </thead>
+                <tbody>
+    """
+
+    for _, row in sentences_df.iterrows():
+        html_content += f"""
+                    <tr>
+                        <td>{html.escape(row['passage_id'])}</td>
+                        <td>{row['sentence_number']}</td>
+                        <td>{html.escape(row['sentence'])}</td>
+                        <td>{html.escape(row['english_sentence'])}</td>
+                    </tr>
+        """
+
+    html_content += """
+                </tbody>
+            </table>
+
+            <footer>
+                Generated on """ + datetime.now().strftime("%Y-%m-%d at %H:%M:%S") + """
+            </footer>
+        </div>
+    </body>
+    </html>
+    """
+
+    with open(os.path.join(output_dir, 'sentences.html'), 'w', encoding='utf-8') as f:
         f.write(html_content)

--- a/website/main.py
+++ b/website/main.py
@@ -12,7 +12,8 @@ from .data import (
     get_analyzed_passages,
     get_mythicness_predictors,
     get_skepticism_predictors,
-    get_proper_nouns_by_passage
+    get_proper_nouns_by_passage,
+    get_all_sentences,
 )
 from .structure import create_website_structure
 from .highlighting import create_predictor_maps
@@ -21,7 +22,8 @@ from .generators import (
     generate_mythic_page,
     generate_skepticism_page,
     generate_mythic_words_page,
-    generate_skeptic_words_page
+    generate_skeptic_words_page,
+    generate_sentences_page,
 )
 
 def parse_arguments():
@@ -49,6 +51,7 @@ def main():
         mythic_predictors = get_mythicness_predictors(conn)
         skeptic_predictors = get_skepticism_predictors(conn)
         proper_nouns_dict = get_proper_nouns_by_passage(conn)
+        sentences_df = get_all_sentences(conn)
         
         if len(passages_df) == 0:
             print("No analyzed passages found in the database.")
@@ -79,6 +82,7 @@ def main():
         generate_skepticism_page(passages_df, skeptic_color_map, skeptic_class_map, proper_nouns_dict, output_dir, args.title)
         generate_mythic_words_page(mythic_predictors, output_dir, args.title)
         generate_skeptic_words_page(skeptic_predictors, output_dir, args.title)
+        generate_sentences_page(sentences_df, output_dir, args.title)
         
         print(f"Website generated successfully in '{output_dir}'")
         print(f"Open '{os.path.join(output_dir, 'index.html')}' in a web browser to view it.")


### PR DESCRIPTION
## Summary
- add database helper and generator to build a site page listing every Greek and English sentence
- link the new sentences page into the website build process and navigation
- drop the TSV export option from `split_sentences.py`

## Testing
- `python -m py_compile split_sentences.py website/data.py website/generators.py website/main.py create_website.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf8943551083259976dd0a8d4dc242