### PR TITLE
Use gpt-5 for OpenAI calls

### DIFF
--- a/extract_proper_nouns.py
+++ b/extract_proper_nouns.py
@@ -21,8 +21,8 @@ def parse_arguments():
                         help="Maximum number of records to process (default: all)")
     parser.add_argument("--progress-bar", action="store_true", default=False,
                         help="Show progress bar")
-    parser.add_argument("--model", default="gpt-4.1",
-                        help="OpenAI model to use (default: gpt-4.1)")
+    parser.add_argument("--model", default="gpt-5",
+                        help="OpenAI model to use (default: gpt-5)")
     parser.add_argument("--debug", action="store_true", default=False,
                         help="Print the full API response for debugging")
     

--- a/mythic_sceptic_analyser.py
+++ b/mythic_sceptic_analyser.py
@@ -23,8 +23,8 @@ def parse_arguments():
                         help="Maximum number of records to process (default: all)")
     parser.add_argument("--progress-bar", action="store_true", default=False,
                         help="Show progress bar")
-    parser.add_argument("--model", default="gpt-4.1",
-                        help="OpenAI model to use (default: gpt-4.1)")
+    parser.add_argument("--model", default="gpt-5",
+                        help="OpenAI model to use (default: gpt-5)")
     
     return parser.parse_args()
 

--- a/sentence_mythic_sceptic_analyser.py
+++ b/sentence_mythic_sceptic_analyser.py
@@ -40,8 +40,8 @@ def parse_arguments():
     )
     parser.add_argument(
         "--model",
-        default="gpt-4.1",
-        help="OpenAI model to use (default: gpt-4.1)",
+        default="gpt-5",
+        help="OpenAI model to use (default: gpt-5)",
     )
     return parser.parse_args()
 

--- a/translate_pausanias.py
+++ b/translate_pausanias.py
@@ -20,8 +20,8 @@ def parse_arguments():
                         help="Maximum number of records to process (default: all)")
     parser.add_argument("--progress-bar", action="store_true", default=False,
                         help="Show progress bar")
-    parser.add_argument("--model", default="gpt-4.5-preview",
-                        help="OpenAI model to use (default: gpt-4.5-preview)")
+    parser.add_argument("--model", default="gpt-5",
+                        help="OpenAI model to use (default: gpt-5)")
     parser.add_argument("--debug", action="store_true", default=False,
                         help="Print the full API response for debugging")
     


### PR DESCRIPTION
## Summary
- Set default OpenAI model to gpt-5 in analyzer, translator, noun extraction, and sentence analyzer scripts.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13062b1d48325ab81cffd63cba7d9