### PR TITLE
Add sentence-level TF-IDF predictors and website pages

### DIFF
--- a/find_sentence_predictors.py
+++ b/find_sentence_predictors.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+
+import argparse
+import sqlite3
+import sys
+import numpy as np
+import pandas as pd
+from datetime import datetime
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+import joblib
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Create TF-IDF and logistic regression models for Pausanias sentences")
+    parser.add_argument("--database", default="pausanias.sqlite", 
+                        help="SQLite database file (default: pausanias.sqlite)")
+    parser.add_argument("--min-samples", type=int, default=20,
+                        help="Minimum number of samples required to build models (default: 20)")
+    parser.add_argument("--test-size", type=float, default=0.2,
+                        help="Proportion of data to use for testing (default: 0.2)")
+    parser.add_argument("--max-features", type=int, default=1000,
+                        help="Maximum number of features for TF-IDF vectorizer (default: 1000)")
+    parser.add_argument("--ngram-range", type=str, default="1,2",
+                        help="N-gram range for TF-IDF vectorizer, format: min,max (default: 1,2)")
+    parser.add_argument("--top-features", type=int, default=30,
+                        help="Number of top predictive features to report (default: 30)")
+    parser.add_argument("--save-models", action="store_true", default=False,
+                        help="Save trained models to disk")
+    
+    return parser.parse_args()
+
+def create_predictor_tables(conn):
+    """Create tables for storing predictive words/phrases for sentences."""
+    # Table for mythicness predictors at sentence level
+    conn.execute('''
+    CREATE TABLE IF NOT EXISTS sentence_mythicness_predictors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        phrase TEXT NOT NULL,
+        coefficient REAL NOT NULL,
+        is_mythic INTEGER NOT NULL,
+        timestamp TEXT NOT NULL
+    )
+    ''')
+
+    # Table for skepticism predictors at sentence level
+    conn.execute('''
+    CREATE TABLE IF NOT EXISTS sentence_skepticism_predictors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        phrase TEXT NOT NULL,
+        coefficient REAL NOT NULL,
+        is_skeptical INTEGER NOT NULL,
+        timestamp TEXT NOT NULL
+    )
+    ''')
+    
+    conn.commit()
+
+def clear_predictor_tables(conn):
+    """Clear existing sentence-level predictor tables before inserting new values."""
+    conn.execute("DELETE FROM sentence_mythicness_predictors")
+    conn.execute("DELETE FROM sentence_skepticism_predictors")
+    conn.commit()
+    print("Cleared existing predictor tables.")
+
+def get_analyzed_sentences(conn):
+    """Get sentences that have been analyzed for mythicness and skepticism."""
+    query = """
+    SELECT sentence, references_mythic_era, expresses_scepticism
+    FROM greek_sentences
+    WHERE references_mythic_era IS NOT NULL
+    AND expresses_scepticism IS NOT NULL
+    """
+
+    df = pd.read_sql_query(query, conn)
+    return df
+
+def get_proper_nouns(conn):
+    """Get all proper nouns to use as stopwords."""
+    query = """
+    SELECT DISTINCT exact_form
+    FROM proper_nouns
+    """
+
+    df = pd.read_sql_query(query, conn)
+    return df['exact_form'].tolist()
+
+def get_manual_stopwords(conn):
+    """Get manually specified stopwords from the database."""
+    # Ensure the table exists so users can manually insert words later
+    conn.execute('''
+    CREATE TABLE IF NOT EXISTS manual_stopwords (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        word TEXT UNIQUE NOT NULL
+    )
+    ''')
+    conn.commit()
+
+    df = pd.read_sql_query("SELECT word FROM manual_stopwords", conn)
+    return df['word'].tolist()
+
+def save_predictors(conn, feature_names, coefficients, label, table_name):
+    """Save predictive features to the database."""
+    timestamp = datetime.now().isoformat()
+    cursor = conn.cursor()
+    
+    for feature, coef in zip(feature_names, coefficients):
+        is_positive = 1 if coef > 0 else 0
+        
+        cursor.execute(
+            f"""
+            INSERT INTO {table_name} (phrase, coefficient, is_{label}, timestamp)
+            VALUES (?, ?, ?, ?)
+            """,
+            (feature, float(coef), is_positive, timestamp)
+        )
+    
+    conn.commit()
+
+def build_and_evaluate_model(X, y, vectorizer_params, model_params, feature_label, conn, table_name, top_n=30):
+    """Build a TF-IDF + LogReg model, evaluate it, and save top predictors."""
+    # Split data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=args.test_size, random_state=42)
+    
+    # Create pipeline
+    pipeline = Pipeline([
+        ('tfidf', TfidfVectorizer(**vectorizer_params)),
+        ('logreg', LogisticRegression(**model_params))
+    ])
+    
+    # Train model
+    pipeline.fit(X_train, y_train)
+    
+    # Evaluate model
+    y_pred = pipeline.predict(X_test)
+    print(f"\n=== {feature_label.capitalize()} Model Evaluation ===")
+    print(classification_report(y_test, y_pred))
+    
+    # Get feature names and coefficients
+    vectorizer = pipeline.named_steps['tfidf']
+    model = pipeline.named_steps['logreg']
+    
+    feature_names = vectorizer.get_feature_names_out()
+    coefficients = model.coef_[0]
+    
+    # Get top positive and negative predictors
+    sorted_indices = np.argsort(coefficients)
+    top_negative_indices = sorted_indices[:top_n]
+    top_positive_indices = sorted_indices[-top_n:]
+    
+    top_negative_features = [(feature_names[i], coefficients[i]) for i in top_negative_indices]
+    top_positive_features = [(feature_names[i], coefficients[i]) for i in top_positive_indices]
+    
+    # Print top predictors
+    print(f"\nTop predictors for NOT {feature_label}:")
+    for feature, coef in top_negative_features:
+        print(f"  {feature}: {coef:.4f}")
+    
+    print(f"\nTop predictors for {feature_label}:")
+    for feature, coef in top_positive_features:
+        print(f"  {feature}: {coef:.4f}")
+    
+    # Save predictors to database
+    all_feature_names = [feature_names[i] for i in np.concatenate([top_negative_indices, top_positive_indices])]
+    all_coefficients = [coefficients[i] for i in np.concatenate([top_negative_indices, top_positive_indices])]
+    save_predictors(conn, all_feature_names, all_coefficients, feature_label, table_name)
+    
+    return pipeline
+
+if __name__ == '__main__':
+    args = parse_arguments()
+    
+    # Parse ngram_range
+    ngram_min, ngram_max = map(int, args.ngram_range.split(','))
+    
+    # Connect to the database
+    conn = sqlite3.connect(args.database)
+    
+    try:
+        # Create predictor tables if they don't exist
+        create_predictor_tables(conn)
+        
+        # Clear existing predictor data
+        clear_predictor_tables(conn)
+        
+        # Get analyzed sentences
+        sentences_df = get_analyzed_sentences(conn)
+
+        if len(sentences_df) < args.min_samples:
+            print(f"Not enough analyzed sentences. Found {len(sentences_df)}, need at least {args.min_samples}.")
+            sys.exit(0)
+
+        print(f"Found {len(sentences_df)} analyzed sentences.")
+        print(f"References mythic era: {sentences_df['references_mythic_era'].sum()} sentences")
+        print(f"Expresses skepticism: {sentences_df['expresses_scepticism'].sum()} sentences")
+        
+        # Get stopwords: proper nouns plus any manually specified additions
+        proper_nouns = get_proper_nouns(conn)
+        manual_stopwords = get_manual_stopwords(conn)
+        all_stopwords = proper_nouns + manual_stopwords
+        print(
+            f"Using {len(proper_nouns)} proper nouns and {len(manual_stopwords)} manual stopwords as stopwords for mythicness model."
+        )
+
+        # Build mythicness model (with stopwords)
+        mythic_vectorizer_params = {
+            'max_features': args.max_features,
+            'ngram_range': (ngram_min, ngram_max),
+            'stop_words': all_stopwords
+        }
+        
+        mythic_model_params = {
+            'C': 1.0,
+            'max_iter': 1000,
+            'class_weight': 'balanced',
+            'random_state': 42
+        }
+        
+        print("\nBuilding mythicness prediction model...")
+        mythic_model = build_and_evaluate_model(
+            sentences_df['sentence'],
+            sentences_df['references_mythic_era'],
+            mythic_vectorizer_params,
+            mythic_model_params,
+            'mythic',
+            conn,
+            'sentence_mythicness_predictors',
+            args.top_features
+        )
+        
+        # Build skepticism model (without proper noun stopwords)
+        skeptic_vectorizer_params = {
+            'max_features': args.max_features,
+            'ngram_range': (ngram_min, ngram_max),
+            'stop_words': []  # No stopwords as requested
+        }
+        
+        skeptic_model_params = {
+            'C': 1.0,
+            'max_iter': 1000,
+            'class_weight': 'balanced',
+            'random_state': 42
+        }
+        
+        print("\nBuilding skepticism prediction model...")
+        skeptic_model = build_and_evaluate_model(
+            sentences_df['sentence'],
+            sentences_df['expresses_scepticism'],
+            skeptic_vectorizer_params,
+            skeptic_model_params,
+            'skeptical',
+            conn,
+            'sentence_skepticism_predictors',
+            args.top_features
+        )
+        
+        # Save models if requested
+        if args.save_models:
+            joblib.dump(mythic_model, 'sentence_mythicness_model.joblib')
+            joblib.dump(skeptic_model, 'sentence_skepticism_model.joblib')
+            print("\nModels saved to disk.")
+        
+        print("\nProcessing complete.")
+    
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+    
+    finally:
+        conn.close()

--- a/website/data.py
+++ b/website/data.py
@@ -84,6 +84,30 @@ def get_skepticism_predictors(conn):
     return df
 
 
+def get_sentence_mythicness_predictors(conn):
+    """Get sentence-level words/phrases that predict mythicness/historicity."""
+    query = """
+    SELECT phrase, coefficient, is_mythic
+    FROM sentence_mythicness_predictors
+    ORDER BY coefficient DESC
+    """
+
+    df = pd.read_sql_query(query, conn)
+    return df
+
+
+def get_sentence_skepticism_predictors(conn):
+    """Get sentence-level words/phrases that predict skepticism/non-skepticism."""
+    query = """
+    SELECT phrase, coefficient, is_skeptical
+    FROM sentence_skepticism_predictors
+    ORDER BY coefficient DESC
+    """
+
+    df = pd.read_sql_query(query, conn)
+    return df
+
+
 def get_all_sentences(conn):
     """Retrieve all Greek and English sentences with analysis flags."""
     query = """

--- a/website/generators.py
+++ b/website/generators.py
@@ -29,6 +29,8 @@ def generate_home_page(output_dir, title, timestamp):
             <a href="mythic_words.html">Mythic Words</a>
             <a href="skeptic_words.html">Skeptic Words</a>
             <a href="sentences.html">Sentences</a>
+            <a href="sentence_mythic_words.html">Sentence Mythic Words</a>
+            <a href="sentence_skeptic_words.html">Sentence Skeptic Words</a>
             <a href="network_viz/index.html">Network Analysis</a>
         </nav>
         
@@ -56,6 +58,8 @@ def generate_home_page(output_dir, title, timestamp):
                 <p>Examine the specific words and phrases that are most strongly associated with mythic content and skepticism.</p>
                 <a href="mythic_words.html">Mythic Predictors</a>
                 <a href="skeptic_words.html">Skepticism Predictors</a>
+                <a href="sentence_mythic_words.html">Sentence Mythic Predictors</a>
+                <a href="sentence_skeptic_words.html">Sentence Skepticism Predictors</a>
             </div>
             
             <footer>
@@ -104,6 +108,8 @@ def generate_mythic_page(passages_df, mythic_color_map, mythic_class_map, proper
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
             <a href=\"../sentences.html\">Sentences</a>
+            <a href=\"../sentence_mythic_words.html\">Sentence Mythic Words</a>
+            <a href=\"../sentence_skeptic_words.html\">Sentence Skeptic Words</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -214,6 +220,8 @@ def generate_mythic_page(passages_df, mythic_color_map, mythic_class_map, proper
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
             <a href=\"../sentences.html\">Sentences</a>
+            <a href=\"../sentence_mythic_words.html\">Sentence Mythic Words</a>
+            <a href=\"../sentence_skeptic_words.html\">Sentence Skeptic Words</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -272,6 +280,8 @@ def generate_skepticism_page(passages_df, skeptic_color_map, skeptic_class_map, 
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
             <a href=\"../sentences.html\">Sentences</a>
+            <a href=\"../sentence_mythic_words.html\">Sentence Mythic Words</a>
+            <a href=\"../sentence_skeptic_words.html\">Sentence Skeptic Words</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -382,6 +392,8 @@ def generate_skepticism_page(passages_df, skeptic_color_map, skeptic_class_map, 
             <a href=\"../mythic_words.html\">Mythic Words</a>
             <a href=\"../skeptic_words.html\">Skeptic Words</a>
             <a href=\"../sentences.html\">Sentences</a>
+            <a href=\"../sentence_mythic_words.html\">Sentence Mythic Words</a>
+            <a href=\"../sentence_skeptic_words.html\">Sentence Skeptic Words</a>
             <a href=\"../network_viz/index.html\">Network Analysis</a>
         </nav>
 
@@ -435,6 +447,8 @@ def generate_mythic_words_page(mythic_predictors, output_dir, title):
             <a href="mythic_words.html" class="active">Mythic Words</a>
             <a href="skeptic_words.html">Skeptic Words</a>
             <a href="sentences.html">Sentences</a>
+            <a href="sentence_mythic_words.html">Sentence Mythic Words</a>
+            <a href="sentence_skeptic_words.html">Sentence Skeptic Words</a>
             <a href="network_viz/index.html">Network Analysis</a>
         </nav>
         
@@ -531,6 +545,8 @@ def generate_skeptic_words_page(skeptic_predictors, output_dir, title):
             <a href="mythic_words.html">Mythic Words</a>
             <a href="skeptic_words.html" class="active">Skeptic Words</a>
             <a href="sentences.html">Sentences</a>
+            <a href="sentence_mythic_words.html">Sentence Mythic Words</a>
+            <a href="sentence_skeptic_words.html">Sentence Skeptic Words</a>
             <a href="network_viz/index.html">Network Analysis</a>
         </nav>
         
@@ -600,6 +616,176 @@ def generate_skeptic_words_page(skeptic_predictors, output_dir, title):
         f.write(html_content)
 
 
+def generate_sentence_mythic_words_page(mythic_predictors, output_dir, title):
+    """Generate a page showing sentence-level predictors of mythic/historical content."""
+
+    mythic_words = mythic_predictors[mythic_predictors['is_mythic'] == 1].sort_values('coefficient', ascending=False)
+    historical_words = mythic_predictors[mythic_predictors['is_mythic'] == 0].sort_values('coefficient', ascending=True)
+
+    html_content = f"""<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{title} - Sentence Mythic Predictors</title>
+        <link rel="stylesheet" href="css/style.css">
+    </head>
+    <body>
+        <header>
+            <h1>{title}</h1>
+            <p>Sentence-level words and phrases that predict mythic vs. historical content</p>
+        </header>
+
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="mythic/index.html">Mythic Analysis</a>
+            <a href="skepticism/index.html">Skepticism Analysis</a>
+            <a href="mythic_words.html">Mythic Words</a>
+            <a href="skeptic_words.html">Skeptic Words</a>
+            <a href="sentences.html">Sentences</a>
+            <a href="sentence_mythic_words.html" class="active">Sentence Mythic Words</a>
+            <a href="sentence_skeptic_words.html">Sentence Skeptic Words</a>
+            <a href="network_viz/index.html">Network Analysis</a>
+        </nav>
+
+        <div class="container">
+            <h2>Sentence Predictors of Mythic Content</h2>
+            <table class="predictor-table">
+                <thead>
+                    <tr><th>Word/Phrase</th><th>Coefficient</th></tr>
+                </thead>
+                <tbody>
+    """
+
+    for _, row in mythic_words.iterrows():
+        html_content += f"""
+                    <tr>
+                        <td class="mythic-word">{html.escape(row['phrase'])}</td>
+                        <td>{row['coefficient']:.4f}</td>
+                    </tr>
+        """
+
+    html_content += """
+                </tbody>
+            </table>
+
+            <h2>Sentence Predictors of Historical Content</h2>
+            <table class="predictor-table">
+                <thead>
+                    <tr><th>Word/Phrase</th><th>Coefficient</th></tr>
+                </thead>
+                <tbody>
+    """
+
+    for _, row in historical_words.iterrows():
+        html_content += f"""
+                    <tr>
+                        <td class="historical-word">{html.escape(row['phrase'])}</td>
+                        <td>{row['coefficient']:.4f}</td>
+                    </tr>
+        """
+
+    html_content += """
+                </tbody>
+            </table>
+
+            <footer>
+                Generated on """ + datetime.now().strftime("%Y-%m-%d at %H:%M:%S") + """
+            </footer>
+        </div>
+    </body>
+    </html>
+    """
+
+    with open(os.path.join(output_dir, 'sentence_mythic_words.html'), 'w', encoding='utf-8') as f:
+        f.write(html_content)
+
+
+def generate_sentence_skeptic_words_page(skeptic_predictors, output_dir, title):
+    """Generate a page showing sentence-level predictors of skepticism."""
+
+    skeptical_words = skeptic_predictors[skeptic_predictors['is_skeptical'] == 1].sort_values('coefficient', ascending=False)
+    non_skeptical_words = skeptic_predictors[skeptic_predictors['is_skeptical'] == 0].sort_values('coefficient', ascending=True)
+
+    html_content = f"""<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{title} - Sentence Skeptic Predictors</title>
+        <link rel="stylesheet" href="css/style.css">
+    </head>
+    <body>
+        <header>
+            <h1>{title}</h1>
+            <p>Sentence-level words and phrases that predict skepticism vs. non-skepticism</p>
+        </header>
+
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="mythic/index.html">Mythic Analysis</a>
+            <a href="skepticism/index.html">Skepticism Analysis</a>
+            <a href="mythic_words.html">Mythic Words</a>
+            <a href="skeptic_words.html">Skeptic Words</a>
+            <a href="sentences.html">Sentences</a>
+            <a href="sentence_mythic_words.html">Sentence Mythic Words</a>
+            <a href="sentence_skeptic_words.html" class="active">Sentence Skeptic Words</a>
+            <a href="network_viz/index.html">Network Analysis</a>
+        </nav>
+
+        <div class="container">
+            <h2>Sentence Predictors of Skeptical Content</h2>
+            <table class="predictor-table">
+                <thead>
+                    <tr><th>Word/Phrase</th><th>Coefficient</th></tr>
+                </thead>
+                <tbody>
+    """
+
+    for _, row in skeptical_words.iterrows():
+        html_content += f"""
+                    <tr>
+                        <td class="skeptical-word">{html.escape(row['phrase'])}</td>
+                        <td>{row['coefficient']:.4f}</td>
+                    </tr>
+        """
+
+    html_content += """
+                </tbody>
+            </table>
+
+            <h2>Sentence Predictors of Non-skeptical Content</h2>
+            <table class="predictor-table">
+                <thead>
+                    <tr><th>Word/Phrase</th><th>Coefficient</th></tr>
+                </thead>
+                <tbody>
+    """
+
+    for _, row in non_skeptical_words.iterrows():
+        html_content += f"""
+                    <tr>
+                        <td class="non-skeptical-word">{html.escape(row['phrase'])}</td>
+                        <td>{row['coefficient']:.4f}</td>
+                    </tr>
+        """
+
+    html_content += """
+                </tbody>
+            </table>
+
+            <footer>
+                Generated on """ + datetime.now().strftime("%Y-%m-%d at %H:%M:%S") + """
+            </footer>
+        </div>
+    </body>
+    </html>
+    """
+
+    with open(os.path.join(output_dir, 'sentence_skeptic_words.html'), 'w', encoding='utf-8') as f:
+        f.write(html_content)
+
+
 def generate_sentences_page(sentences_df, output_dir, title):
     """Generate a page listing Greek passages split into sentences."""
 
@@ -624,6 +810,8 @@ def generate_sentences_page(sentences_df, output_dir, title):
             <a href=\"mythic_words.html\">Mythic Words</a>
             <a href=\"skeptic_words.html\">Skeptic Words</a>
             <a href=\"sentences.html\" class=\"active\">Sentences</a>
+            <a href=\"sentence_mythic_words.html\">Sentence Mythic Words</a>
+            <a href=\"sentence_skeptic_words.html\">Sentence Skeptic Words</a>
             <a href=\"network_viz/index.html\">Network Analysis</a>
         </nav>
 

--- a/website/main.py
+++ b/website/main.py
@@ -14,6 +14,8 @@ from .data import (
     get_skepticism_predictors,
     get_proper_nouns_by_passage,
     get_all_sentences,
+    get_sentence_mythicness_predictors,
+    get_sentence_skepticism_predictors,
 )
 from .structure import create_website_structure
 from .highlighting import create_predictor_maps
@@ -24,6 +26,8 @@ from .generators import (
     generate_mythic_words_page,
     generate_skeptic_words_page,
     generate_sentences_page,
+    generate_sentence_mythic_words_page,
+    generate_sentence_skeptic_words_page,
 )
 
 def parse_arguments():
@@ -52,18 +56,26 @@ def main():
         skeptic_predictors = get_skepticism_predictors(conn)
         proper_nouns_dict = get_proper_nouns_by_passage(conn)
         sentences_df = get_all_sentences(conn)
+        sentence_mythic_predictors = get_sentence_mythicness_predictors(conn)
+        sentence_skeptic_predictors = get_sentence_skepticism_predictors(conn)
         
         if len(passages_df) == 0:
             print("No analyzed passages found in the database.")
             sys.exit(0)
         
         if len(mythic_predictors) == 0 or len(skeptic_predictors) == 0:
-            print("No predictor data found in the database. Run the analysis program first.")
+            print("No passage-level predictor data found in the database. Run the analysis program first.")
+            sys.exit(1)
+
+        if len(sentence_mythic_predictors) == 0 or len(sentence_skeptic_predictors) == 0:
+            print("No sentence-level predictor data found in the database. Run the sentence analysis program.")
             sys.exit(1)
         
         print(f"Found {len(passages_df)} analyzed passages.")
         print(f"Found {len(mythic_predictors)} mythicness predictors.")
         print(f"Found {len(skeptic_predictors)} skepticism predictors.")
+        print(f"Found {len(sentence_mythic_predictors)} sentence-level mythicness predictors.")
+        print(f"Found {len(sentence_skeptic_predictors)} sentence-level skepticism predictors.")
         
         # Create website structure
         output_dir, css_dir = create_website_structure(args.output_dir)
@@ -83,6 +95,8 @@ def main():
         generate_mythic_words_page(mythic_predictors, output_dir, args.title)
         generate_skeptic_words_page(skeptic_predictors, output_dir, args.title)
         generate_sentences_page(sentences_df, output_dir, args.title)
+        generate_sentence_mythic_words_page(sentence_mythic_predictors, output_dir, args.title)
+        generate_sentence_skeptic_words_page(sentence_skeptic_predictors, output_dir, args.title)
         
         print(f"Website generated successfully in '{output_dir}'")
         print(f"Open '{os.path.join(output_dir, 'index.html')}' in a web browser to view it.")


### PR DESCRIPTION
## Summary
- Add `find_sentence_predictors.py` to build TF-IDF+logistic regression models on sentence annotations and store predictors in new database tables.
- Extend website data access and generators to include sentence-level mythic and skeptical predictor pages and navigation links.
- Update main site builder to load sentence predictor data and emit the new pages.

## Testing
- `python -m py_compile find_sentence_predictors.py website/data.py website/generators.py website/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c13361fa108325b66bee635ebf0618