### PR TITLE
Expose mythic predictor counts on website

### DIFF
--- a/website/data.py
+++ b/website/data.py
@@ -64,11 +64,11 @@ def get_analyzed_passages(conn, limit=None):
 def get_mythicness_predictors(conn):
     """Get words/phrases that predict mythicness/historicity."""
     query = """
-    SELECT phrase, coefficient, is_mythic
+    SELECT phrase, coefficient, is_mythic, mythic_count, non_mythic_count
     FROM mythicness_predictors
     ORDER BY coefficient DESC
     """
-    
+
     df = pd.read_sql_query(query, conn)
     return df
 

--- a/website/generators.py
+++ b/website/generators.py
@@ -461,17 +461,21 @@ def generate_mythic_words_page(mythic_predictors, output_dir, title):
                     <tr>
                         <th>Word/Phrase</th>
                         <th>Coefficient</th>
+                        <th>Mythic Count</th>
+                        <th>Non-mythic Count</th>
                     </tr>
                 </thead>
                 <tbody>
     """
-    
+
     # Add mythic predictors
     for _, row in mythic_words.iterrows():
         html_content += f"""
                     <tr>
                         <td class="mythic-word">{html.escape(row['phrase'])}</td>
                         <td>{row['coefficient']:.4f}</td>
+                        <td>{row['mythic_count']}</td>
+                        <td>{row['non_mythic_count']}</td>
                     </tr>
         """
     
@@ -487,17 +491,21 @@ def generate_mythic_words_page(mythic_predictors, output_dir, title):
                     <tr>
                         <th>Word/Phrase</th>
                         <th>Coefficient</th>
+                        <th>Mythic Count</th>
+                        <th>Non-mythic Count</th>
                     </tr>
                 </thead>
                 <tbody>
     """
-    
+
     # Add historical predictors
     for _, row in historical_words.iterrows():
         html_content += f"""
                     <tr>
                         <td class="historical-word">{html.escape(row['phrase'])}</td>
                         <td>{row['coefficient']:.4f}</td>
+                        <td>{row['mythic_count']}</td>
+                        <td>{row['non_mythic_count']}</td>
                     </tr>
         """
     


### PR DESCRIPTION
## Summary
- Retrieve `mythic_count` and `non_mythic_count` for mythicness predictors.
- Display mythic and non-mythic occurrence counts on the Mythic Words page for both mythic and historical predictors.

## Testing
- `python -m py_compile website/data.py website/generators.py`


------
https://chatgpt.com/codex/tasks/task_e_68c52b6765388325b2fe1c680eabbe6b